### PR TITLE
Make `BarLineChartViewBase.autoscale` method open

### DIFF
--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -299,7 +299,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     private var _autoScaleLastHighestVisibleX: Double?
     
     /// Performs auto scaling of the axis by recalculating the minimum and maximum y-values based on the entries currently in view.
-    internal func autoScale()
+    open func autoScale()
     {
         guard let data = data
             else { return }


### PR DESCRIPTION
### Solution
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->
Open up the `BarLineChartViewBase.autoScale` method so it can be overridden.

### Steps to Test or Reproduce
Clone the project (if you haven't already) and run the tests in the test target (`ChartsTests`).